### PR TITLE
An option to put image dimensions in the CSS files rather than inline HTML

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,9 @@ module.exports = function(grunt) {
 				// prefix for CSS classnames
 				cssprefix: "icon-",
 
+				// Whether to include the px height and width in the generated CSS files
+				cssdimensions: false,
+
 				// css file path prefix - this defaults to "/" and will be placed before the "dest" path when stylesheets are loaded.
 				// This allows root-relative referencing of the CSS. If you don't want a prefix path, set to to ""
 				cssbasepath: "/"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In addition to the required configuration properties above, grunticon's grunt co
 - `loadersnippet`:  The name of the generated text file containing the grunticon loading snippet. Default: `"grunticon.loader.txt"`
 - `pngfolder`:  The name of the generated folder containing the generated PNG images. Default: `"png/"`
 - `cssprefix`: a string to prefix all css classes with. Default: `"icon-"`
+- `cssdimensions`: Whether to include the px height and width in the generated CSS files. Default: `false`
 
 ## Notable forks
 

--- a/example/output/preview.html
+++ b/example/output/preview.html
@@ -10,26 +10,26 @@ grunticon( [ "icons.data.svg.css", "icons.data.png.css", "icons.fallback.css" ] 
 	<noscript><link href="icons.fallback.css" rel="stylesheet"></noscript>
 	</head>
 	<body>
-	<pre><code>.icon-arrow-11:</code></pre><div class="icon-arrow-11" style="width: 30px; height: 30px"></div><hr/>
-	<pre><code>.icon-arrow-tiny:</code></pre><div class="icon-arrow-tiny" style="width: 30px; height: 30px"></div><hr/>
-	<pre><code>.icon-bear:</code></pre><div class="icon-bear" style="width: 100px; height: 62.905px"></div><hr/>
-	<pre><code>.icon-cat:</code></pre><div class="icon-cat" style="width: 100px; height: 100px"></div><hr/>
-	<pre><code>.icon-flag:</code></pre><div class="icon-flag" style="width: 36px; height: 26px"></div><hr/>
-	<pre><code>.icon-gear:</code></pre><div class="icon-gear" style="width: 30px; height: 30px"></div><hr/>
-	<pre><code>.icon-gradients-flat-opacity:</code></pre><div class="icon-gradients-flat-opacity" style="width: 84.501px; height: 42px"></div><hr/>
-	<pre><code>.icon-gradients:</code></pre><div class="icon-gradients" style="width: 30px; height: 30px"></div><hr/>
-	<pre><code>.icon-grunticon:</code></pre><div class="icon-grunticon" style="width: 100px; height: 100px"></div><hr/>
-	<pre><code>.icon-gummy-bears-1:</code></pre><div class="icon-gummy-bears-1" style="width: 340px; height: 448px"></div><hr/>
-	<pre><code>.icon-gummy-bears-2:</code></pre><div class="icon-gummy-bears-2" style="width: 340px; height: 449px"></div><hr/>
-	<pre><code>.icon-Home_Media:</code></pre><div class="icon-Home_Media" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-Image_Exchange:</code></pre><div class="icon-Image_Exchange" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-Internet:</code></pre><div class="icon-Internet" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-Internet_FP2:</code></pre><div class="icon-Internet_FP2" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-Internet_Radio:</code></pre><div class="icon-Internet_Radio" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-Internet_Tel:</code></pre><div class="icon-Internet_Tel" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-Intranet:</code></pre><div class="icon-Intranet" style="width: 44px; height: 44px"></div><hr/>
-	<pre><code>.icon-map:</code></pre><div class="icon-map" style="width: 24px; height: 34px"></div><hr/>
-	<pre><code>.icon-plus:</code></pre><div class="icon-plus" style="width: 30px; height: 30px"></div><hr/>
-	<pre><code>.icon-star:</code></pre><div class="icon-star" style="width: 42px; height: 42px"></div><hr/>
+	<pre><code>.icon-arrow-11:</code></pre><div class="icon-arrow-11" style="width: 30px; height: 30px;"></div><hr/>
+	<pre><code>.icon-arrow-tiny:</code></pre><div class="icon-arrow-tiny" style="width: 30px; height: 30px;"></div><hr/>
+	<pre><code>.icon-bear:</code></pre><div class="icon-bear" style="width: 100px; height: 62.905px;"></div><hr/>
+	<pre><code>.icon-cat:</code></pre><div class="icon-cat" style="width: 100px; height: 100px;"></div><hr/>
+	<pre><code>.icon-flag:</code></pre><div class="icon-flag" style="width: 36px; height: 26px;"></div><hr/>
+	<pre><code>.icon-gear:</code></pre><div class="icon-gear" style="width: 30px; height: 30px;"></div><hr/>
+	<pre><code>.icon-gradients-flat-opacity:</code></pre><div class="icon-gradients-flat-opacity" style="width: 84.501px; height: 42px;"></div><hr/>
+	<pre><code>.icon-gradients:</code></pre><div class="icon-gradients" style="width: 30px; height: 30px;"></div><hr/>
+	<pre><code>.icon-grunticon:</code></pre><div class="icon-grunticon" style="width: 100px; height: 100px;"></div><hr/>
+	<pre><code>.icon-gummy-bears-1:</code></pre><div class="icon-gummy-bears-1" style="width: 340px; height: 448px;"></div><hr/>
+	<pre><code>.icon-gummy-bears-2:</code></pre><div class="icon-gummy-bears-2" style="width: 340px; height: 449px;"></div><hr/>
+	<pre><code>.icon-Home_Media:</code></pre><div class="icon-Home_Media" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-Image_Exchange:</code></pre><div class="icon-Image_Exchange" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-Internet:</code></pre><div class="icon-Internet" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-Internet_FP2:</code></pre><div class="icon-Internet_FP2" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-Internet_Radio:</code></pre><div class="icon-Internet_Radio" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-Internet_Tel:</code></pre><div class="icon-Internet_Tel" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-Intranet:</code></pre><div class="icon-Intranet" style="width: 44px; height: 44px;"></div><hr/>
+	<pre><code>.icon-map:</code></pre><div class="icon-map" style="width: 24px; height: 34px;"></div><hr/>
+	<pre><code>.icon-plus:</code></pre><div class="icon-plus" style="width: 30px; height: 30px;"></div><hr/>
+	<pre><code>.icon-star:</code></pre><div class="icon-star" style="width: 42px; height: 42px;"></div><hr/>
 </body>
 </html>

--- a/lib/grunticoner.js
+++ b/lib/grunticoner.js
@@ -73,6 +73,7 @@
 		// add rules to svg data css file
 		var res = {};
 		var prefix = o.cssprefix + filenamenoext;
+		var cssdims = o.cssdimensions;
 		var pngdatauri = "'data:image/png;base64,";
 		var svgdatauri = "'data:image/svg+xml;charset=US-ASCII,";
 
@@ -94,23 +95,24 @@
 		var getPNGDataCSSRule = function( prefix , pngimgstring ){
 			if (pngimgstring.length <= 32768) {
 				// create png data URI
-				return "." + prefix + " { background-image: url(" +  pngdatauri + "); background-repeat: no-repeat; }";
+				return "." + prefix + " { background-image: url(" +  pngdatauri + "); " + ( cssdims ? widthandheight + ' ' : '') + "background-repeat: no-repeat; }";
 			} else {
 				return "/* Using an external URL reference because this image would have a data URI of " +
 					pngimgstring.length +
 					" characters, which is greater than the maximum of 32768 allowed by IE8. */\n" +
-					"." + prefix + " { background-image: url(" + o.pngout + filenamenoext + ".png" + "); background-repeat: no-repeat; }";
+					"." + prefix + " { background-image: url(" + o.pngout + filenamenoext + ".png" + "); " + ( cssdims ? widthandheight + ' ' : '') + "background-repeat: no-repeat; }";
 			}
 		}; //getPNGDataCSSRule
 		if( isSvg ) {
 			svgdatauri += buildSVGDataURI( imagedata );
 		}
 
+		var widthandheight = 'width: ' + width + '; height: ' + height + ';';
 		pngdatauri += pngimgstring + "'";
 
-		res.pngcssrule = '.' + prefix + " { background-image: url(" + o.pngout + filenamenoext + ".png" + "); background-repeat: no-repeat; }";
-		res.htmlmarkup = '<pre><code>.' + prefix + ':</code></pre><div class="' + prefix + '" style="width: '+ width +'; height: '+ height +'"></div><hr/>';
-		res.datacssrule = "." + prefix + " { background-image: url(" + ( isSvg ? svgdatauri : pngdatauri ) + "); background-repeat: no-repeat; }";
+		res.pngcssrule = '.' + prefix + " { background-image: url(" + o.pngout + filenamenoext + ".png" + "); " + ( cssdims ? widthandheight + ' ' : '') + "background-repeat: no-repeat; }";
+		res.htmlmarkup = '<pre><code>.' + prefix + ':</code></pre><div class="' + prefix + '"' + ( cssdims ? '' : ' style="' + widthandheight + '"') +'></div><hr/>';
+		res.datacssrule = "." + prefix + " { background-image: url(" + ( isSvg ? svgdatauri : pngdatauri ) + "); " + ( cssdims ? widthandheight + ' ' : '') + "background-repeat: no-repeat; }";
 		res.pngdatacssrule = getPNGDataCSSRule( prefix , pngimgstring );
 
 		return res;
@@ -137,7 +139,7 @@
 		} ); //page.open
 		return renderp;
 	}; // render
-	
+
 
 
 

--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -61,6 +61,9 @@ module.exports = function( grunt , undefined ) {
 		// css references base path for the loader
 		var cssbasepath = config.cssbasepath || "/";
 
+		// Whether to include the px height and width in the generated CSS files.
+		var cssdimensions = config.cssdimensions || false;
+
 		// folder name (within the output folder) for generated png files
 		var pngfolder = config.pngfolder || "png/";
 		// make sure pngfolder has / at the end
@@ -105,7 +108,8 @@ module.exports = function( grunt , undefined ) {
 				previewhtml,
 				pngfolder,
 				cssprefix,
-				cssbasepath
+				cssbasepath,
+				cssdimensions
 			],
 			fallback: ''
 		}, function(err, result, code) {

--- a/tasks/grunticon/phantom.js
+++ b/tasks/grunticon/phantom.js
@@ -23,6 +23,7 @@ phantom args sent from grunticon.js:
 	[8] - png folder name
 	[9] - css classname prefix
 	[10] - css basepath prefix
+	[11] - put dimensions in css
 */
 
 (function(){
@@ -43,7 +44,8 @@ phantom args sent from grunticon.js:
 		cssbasepath: phantom.args[10],
 		asyncCSSpath: phantom.args[2],
 		previewFilePath: phantom.args[3],
-		previewHTMLFilePath: phantom.args[7]
+		previewHTMLFilePath: phantom.args[7],
+		cssdimensions: (phantom.args[11].toLowerCase() === 'true')
 	};
 
 	var files = fs.list( options.inputdir );


### PR DESCRIPTION
This commit adds a `cssdimensions` option that takes a boolean argument, which defaults to `false`. If set to `true`, the height and width of each image are added to the class declarations in each CSS file, rather than as inline styles on the preview HTML file.
