### PR TITLE
Increase maxBuffer for pngcrusher to be able to run Font Awesome

### DIFF
--- a/lib/pngcrusher.js
+++ b/lib/pngcrusher.js
@@ -68,21 +68,24 @@
 			output = options.outputDir,
 			outputFile = options.outputFilename,
 			pngCrushPath = options.crushPath,
-			filequery;
+			filequery,
+            childProcessOptions = {
+                maxBuffer: options.maxBuffer * 1024
+            };
 
 		if( typeof output !== "undefined" && output !== null ){
 			this.makeOutputDir( output, isDirectory( absInput ) );
 		}
 		if( isDirectory( absInput ) ){
 			filequery = this.buildQuery( absInput , output );
-			execFile( pngCrushPath , filequery , null, function( err , stdout, stderr ){
+			execFile( pngCrushPath , filequery , childProcessOptions, function( err , stdout, stderr ){
 				if( err ){
 					console.log( err );
 				}
 				callback( stdout , stderr );
 			});
 		} else {
-			execFile( pngCrushPath, [ input , output + outputFile ] , null , function( err , stdout, stderr ){
+			execFile( pngCrushPath, [ input , output + outputFile ] , childProcessOptions , function( err , stdout, stderr ){
 				if( err ){
 					console.log( err );
 				}

--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -295,7 +295,8 @@ module.exports = function( grunt , undefined ) {
 				crusher.crush({
 					input: tmpPngfolder,
 					outputDir:  path.join( config.dest , pngfolder ),
-					crushPath: crushPath
+					crushPath: crushPath,
+                    maxBuffer: 250
 				}, function( stdout , stderr ){
 					grunt.verbose.write( stdout );
 					grunt.verbose.write( stderr );


### PR DESCRIPTION
I was attempting to run [Font Awesome](https://github.com/FortAwesome/Font-Awesome) through Grunticon and was running into the following:

> Error: stderr maxBuffer exceeded.

After looking through some Node.js documentation I stumbled upon [maxBuffer](http://nodejs.org/api/child_process.html) and found that increasing it for the pngcrusher child process fixed the issue.

The default is 200 and I found that 250 seemed to be the smallest increase that works with running Font Awesome. I tried to extract it as much as possible so anyone else can easily update themselves.
