### PR TITLE
Fix regex bug and add support for other svg elements

### DIFF
--- a/lib/grunticon-file.js
+++ b/lib/grunticon-file.js
@@ -175,7 +175,7 @@
 				colorConfig.forEach( function( color, i ){
 					var colorVar = colors[ color ],
 						newFileName = file.replace( colorsRegx, "-" + ( colorVar ? color : i + 1 ) ) ,
-						newFileContents = fileContents.replace( /(<svg[^>]+)/im, '$1><style type="text/css">path { fill: ' + (colorVar || color) + ' !important; }</style>' ),
+						newFileContents = fileContents.replace( /(<svg[^>]+>)/im, '$1<style type="text/css">circle, ellipse, line, path, polygon, polyline, rect, text { fill: ' + (colorVar || color) + ' !important; }</style>' ),
 						newFilePath = path.join( options.inputDir, newFileName );
 
 					tempFiles.push( newFileName );

--- a/tasks/grunticon/phantom.js
+++ b/tasks/grunticon/phantom.js
@@ -119,7 +119,7 @@ phantom args sent from grunticon.js:
 			colorConfig.forEach( function( color, i ){
 				var colorVar = colors[ color ],
 					newFileName = file.replace( colorsRegx, "-" + ( colorVar ? color : i + 1 ) ) ,
-					newFileContents = fileContents.replace( /(<svg[^>]+)/im, '$1><style type="text/css">path { fill: ' + (colorVar || color) + ' !important; }</style>' ),
+					newFileContents = fileContents.replace( /(<svg[^>]+>)/im, '$1<style type="text/css">circle, ellipse, line, path, polygon, polyline, rect, text { fill: ' + (colorVar || color) + ' !important; }</style>' ),
 					newFilePath = options.inputdir + "/" + newFileName;
 
 				tempFiles.push( newFilePath );


### PR DESCRIPTION
This fixes an issue with the regex that ended up doing `</style>>`. It also adds support for other elements because not all SVGs are made of paths.
