### PR TITLE
Add support for match-all custom selectors - resolves #72

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,7 @@ module.exports = function(grunt) {
 					// This allows root-relative referencing of the CSS. If you don't want a prefix path, set to to ""
 					cssbasepath: "/",
 					customselectors: {
+						"*"   : ".$1--large, .sidebar .$1",
 						"cat" : "#el-gato",
 						"gummy-bears-2" : "nav li a.deadly-bears:before"
 					}

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In addition to the required configuration properties above, grunticon's grunt co
 - `loadersnippet`:  The name of the generated text file containing the grunticon loading snippet. Default: `"grunticon.loader.txt"`
 - `pngfolder`:  The name of the generated folder containing the generated PNG images. Default: `"png/"`
 - `cssprefix`: a string to prefix all css classes with. Default: `"icon-"`
-- `customselectors`: Allows you to specify custom selectors (in addition to the generated `cssprefix + filename - extension` class) for individual files. 
+- `customselectors`: Allows you to specify custom selectors (in addition to the generated `cssprefix + filename - extension` class) for individual files. Use '*' to specify additional selectors for all icons.
 - `defaultWidth`: a string that MUST be defined in px that will be the
   size of the PNG if there is no width given in the SVG element.
 Example: `defaultWidth: "300px";` Default: `"400px"`

--- a/lib/grunticon-file.js
+++ b/lib/grunticon-file.js
@@ -192,8 +192,15 @@
 		var res = {};
 		var cssselectors = config.customselectors || {};
 		var prefix = cssprefix + this.filenamenoext;
-		var iconclass = "." + prefix;
-		var iconsel = cssselectors[ this.filenamenoext ] !== undefined ? iconclass + ",\n" + cssselectors[ this.filenamenoext ] : iconclass;
+		var iconsel = "." + prefix;
+
+		// Add any match-all selectors
+		if ( cssselectors[ '*' ] !== undefined ) {
+			iconsel += ",\n" + cssselectors[ '*' ].replace(/\$1/g, prefix);
+		}
+		// Add any icon-specific selectors
+		iconsel = cssselectors[ this.filenamenoext ] !== undefined ? ",\n" + cssselectors[ this.filenamenoext ] : iconsel;
+
 
 		var getPNGDataCSSRule = function( prefix, pngdatauri, relPngLocation ){
 			if (pngdatauri.length <= 32768) {

--- a/lib/grunticoner.js
+++ b/lib/grunticoner.js
@@ -96,8 +96,14 @@
 		var svgdatauri = "'data:image/svg+xml;charset=US-ASCII,";
 		var cssselectors = o.customselectors ? JSON.parse( o.customselectors ) : JSON.parse( "{}" );
 		var prefix = o.cssprefix + filenamenoext;
-		var iconclass = "." + prefix;
-		var iconsel = cssselectors[ filenamenoext ] !== undefined ? iconclass + ",\n" + cssselectors[ filenamenoext ] : iconclass;
+		var iconsel = "." + prefix;
+
+		// Add any match-all selectors
+		if ( cssselectors[ '*' ] !== undefined ) {
+			iconsel += ",\n" + cssselectors[ '*' ].replace(/\$1/g, prefix);
+		}
+		// Add any icon-specific selectors
+		iconsel = cssselectors[ filenamenoext ] !== undefined ? ",\n" + cssselectors[ filenamenoext ] : iconsel;
 
 		var buildSVGDataURI = function( imagedata ){
 			// get base64 of svg file


### PR DESCRIPTION
Feature for adding selectors to all icons. Assign the selector values to customselectors['*']. Multiple selectors can be comma delimited. $1 can be used to insert the icon name. See Gruntfile for example.
