### PR TITLE
Quote node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - 0.8
-  - 0.10
+  - "0.10"


### PR DESCRIPTION
Otherwise the YAML parser strips the trailing zero
