### PR TITLE
Added quotes around png images to allow spaces within filenames

### DIFF
--- a/lib/grunticon-file.js
+++ b/lib/grunticon-file.js
@@ -208,7 +208,7 @@
 			}
 		}; //getPNGDataCSSRule
 
-		res.pngcssrule = iconsel + " { background-image: url(" + pngfolder.split( path.sep ).join( "/" ) + this.filenamenoext + ".png" + "); background-repeat: no-repeat; }";
+		res.pngcssrule = iconsel + " { background-image: url('" + pngfolder.split( path.sep ).join( "/" ) + this.filenamenoext + ".png" + "'); background-repeat: no-repeat; }";
 		res.htmlmarkup = '<pre><code>.' + prefix + ':</code></pre><div class="' + prefix + '" style="width: '+ stats.width +'; height: '+ stats.height +'"></div><hr/>';
 		res.datacssrule = iconsel + " { background-image: url('" + ( this.isSvg ? this.svgdatauri() : this.pngdatauri() ) + "'); background-repeat: no-repeat; }";
 		res.pngdatacssrule = getPNGDataCSSRule( prefix , this.pngdatauri(), this.relPngLocation );


### PR DESCRIPTION
I find this little change really useful, by adding the quotes around the filenames you can include spaces in the filename and the resulting png background will show up in internet explorer, without the change they will not. If I need to target an element using grunticon I will sometimes include a space in the file name for example.

_filename_
the-element span.svg

_resulting grunticon selector_
.the-element span{ }
