### PR TITLE
Add ability to batch background-repeat into one rule

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
 					// required config
 					src: "example/source/",
 					dest: "example/output/",
+					batchbackgroundrepeat: true,
 
 					// optional grunticon config properties
 					// SVGO compression, false is the default, true will make it so

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ In addition to the required configuration properties above, grunticon's grunt co
 - `pngfolder`:  The name of the generated folder containing the generated PNG images. Default: `"png/"`
 - `cssprefix`: a string to prefix all css classes with. Default: `"icon-"`
 - `customselectors`: Allows you to specify custom selectors (in addition to the generated `cssprefix + filename - extension` class) for individual files. 
+- `batchbackgroundrepeat`: Batch all `background-repeat`s into one rule at the start of the respective CSS file as opposed to applying to each icon specifically. Default: `false` 
 - `defaultWidth`: a string that MUST be defined in px that will be the
   size of the PNG if there is no width given in the SVG element.
 Example: `defaultWidth: "300px";` Default: `"400px"`

--- a/lib/grunticon-file.js
+++ b/lib/grunticon-file.js
@@ -195,23 +195,39 @@
 		var iconclass = "." + prefix;
 		var iconsel = cssselectors[ this.filenamenoext ] !== undefined ? iconclass + ",\n" + cssselectors[ this.filenamenoext ] : iconclass;
 
-		var getPNGDataCSSRule = function( prefix, pngdatauri, relPngLocation ){
+		var getPNGDataCSSRule = function( prefix, pngdatauri, relPngLocation, batchbackground ){
 			if (pngdatauri.length <= 32768) {
 				// create png data URI
+				if( batchbackground ){
+					return iconsel + " { background-image: url('" +  pngdatauri + "'); }";
+				}
 				return iconsel + " { background-image: url('" +  pngdatauri + "'); background-repeat: no-repeat; }";
 			} else {
-				return "/* Using an external URL reference because this image would have a data URI of " +
-					pngdatauri.length +
-					" characters, which is greater than the maximum of 32768 allowed by IE8. */\n" +
-					iconsel + " { background-image: url('" + relPngLocation.split( path.sep ).join( "/" ) + "'); background-repeat: no-repeat; }";
+				if( batchbackground ){
+					return "/* Using an external URL reference because this image would have a data URI of " +
+						pngdatauri.length +
+						" characters, which is greater than the maximum of 32768 allowed by IE8. */\n" +
+						iconsel + " { background-image: url('" + relPngLocation.split( path.sep ).join( "/" ) + "'); }";
+				} else {
+					return "/* Using an external URL reference because this image would have a data URI of " +
+						pngdatauri.length +
+						" characters, which is greater than the maximum of 32768 allowed by IE8. */\n" +
+						iconsel + " { background-image: url('" + relPngLocation.split( path.sep ).join( "/" ) + "'); background-repeat: no-repeat; }";				
+				}
 
 			}
 		}; //getPNGDataCSSRule
-
-		res.pngcssrule = iconsel + " { background-image: url(" + pngfolder.split( path.sep ).join( "/" ) + this.filenamenoext + ".png" + "); background-repeat: no-repeat; }";
+		
+		if(config.batchbackgroundrepeat){
+			res.backgroundrepeatrule = iconsel;
+			res.pngcssrule = iconsel + " { background-image: url(" + pngfolder.split( path.sep ).join( "/" ) + this.filenamenoext + ".png" + "); }";
+			res.datacssrule = iconsel + " { background-image: url('" + ( this.isSvg ? this.svgdatauri() : this.pngdatauri() ) + "'); }";
+		} else {
+			res.pngcssrule = iconsel + " { background-image: url(" + pngfolder.split( path.sep ).join( "/" ) + this.filenamenoext + ".png" + "); background-repeat: no-repeat; }";
+			res.datacssrule = iconsel + " { background-image: url('" + ( this.isSvg ? this.svgdatauri() : this.pngdatauri() ) + "'); background-repeat: no-repeat; }";
+		}
 		res.htmlmarkup = '<pre><code>.' + prefix + ':</code></pre><div class="' + prefix + '" style="width: '+ stats.width +'; height: '+ stats.height +'"></div><hr/>';
-		res.datacssrule = iconsel + " { background-image: url('" + ( this.isSvg ? this.svgdatauri() : this.pngdatauri() ) + "'); background-repeat: no-repeat; }";
-		res.pngdatacssrule = getPNGDataCSSRule( prefix , this.pngdatauri(), this.relPngLocation );
+		res.pngdatacssrule = getPNGDataCSSRule( prefix , this.pngdatauri(), this.relPngLocation, config.batchbackgroundrepeat );
 		return res;
 	};
 
@@ -220,6 +236,7 @@
 			pngdatacssrules = [],
 			datacssrules = [],
 			htmlpreviewbody = [],
+			batchbackgroundrepeatrules = [],
 			htmldoc, filesnippet, noscript, asyncCSSFile, asyncCSS;
 
 		noscript = '<noscript><link href="' + path.join( o.cssbasepath , o.outputdir , o.fallbackcss ) + '" rel="stylesheet"></noscript>';
@@ -234,6 +251,7 @@
 			pngdatacssrules.push( dataset.pngdatacssrule );
 			datacssrules.push( dataset.datacssrule );
 			htmlpreviewbody.push( dataset.htmlmarkup );
+			batchbackgroundrepeatrules.push (dataset.backgroundrepeatrule );
 		});
 
 		htmldoc = createHTMLDoc( htmlpreviewbody , asyncCSSFile , o );
@@ -243,9 +261,15 @@
 		fs.writeFileSync( path.join( o.outputdir , o.previewFilePath ), htmldoc );
 
 		// write CSS files
-		fs.writeFileSync( path.join( o.outputdir, o.fallbackcss ), pngcssrules.join( "\n\n" ) );
-		fs.writeFileSync( path.join( o.outputdir, o.pngdatacss ), pngdatacssrules.join( "\n\n" ) );
-		fs.writeFileSync( path.join( o.outputdir, o.datacss ), datacssrules.join( "\n\n" ) );
+		if(o.batchbackgroundrepeat){
+			fs.writeFileSync( path.join( o.outputdir, o.fallbackcss ), batchbackgroundrepeatrules.join( ", " ) + "\n{ background-repeat: no-repeat; }\n\n" + pngcssrules.join( "\n\n" ) );
+			fs.writeFileSync( path.join( o.outputdir, o.pngdatacss ), batchbackgroundrepeatrules.join( ", " ) + "\n{ background-repeat: no-repeat; }\n\n" + pngdatacssrules.join( "\n\n" ) );
+			fs.writeFileSync( path.join( o.outputdir, o.datacss ), batchbackgroundrepeatrules.join( ", " ) + "\n{ background-repeat: no-repeat; }\n\n" + datacssrules.join( "\n\n" ) + "\n\n" + batchbackgroundrepeatrules.join( "," ) );
+		} else {
+			fs.writeFileSync( path.join( o.outputdir, o.fallbackcss ), pngcssrules.join( "\n\n" ) );
+			fs.writeFileSync( path.join( o.outputdir, o.pngdatacss ), pngdatacssrules.join( "\n\n" ) );
+			fs.writeFileSync( path.join( o.outputdir, o.datacss ), datacssrules.join( "\n\n" ) );		
+		}
 
 		// overwrite the snippet HTML
 		fs.writeFileSync( o.asyncCSSpath , filesnippet );

--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -159,6 +159,11 @@ module.exports = function( grunt , undefined ) {
 			cssprefix = "icon-";
 		}
 
+		// batch background-repeat
+		var batchbackgroundrepeat = config.batchbackgroundrepeat;
+		if( config.batchbackgroundrepeat === undefined ){
+			batchbackgroundrepeat = config.batchbackgroundrepeat = false;
+		}
 
 		var width = config.defaultWidth;
 		if( !width ){
@@ -314,7 +319,8 @@ module.exports = function( grunt , undefined ) {
 							datacss: datasvgcss,
 							outputdir: config.dest,
 							fallbackcss: urlpngcss,
-							cssbasepath: cssbasepath
+							cssbasepath: cssbasepath,
+							batchbackgroundrepeat: batchbackgroundrepeat
 						};
 						files = files.filter( function( file ){
 							var stats = fs.lstatSync( path.resolve( path.join( tmp , file ) ) );


### PR DESCRIPTION
Added ability to batch the `background-repeat:no-repeat;` style.
Defaults to false.
Specifying `batchbackgroundrepeat: true` in Gruntfile will make one rule at start of respective CSS file(s) an omit applying this style specifically to each icon.  
Discussed in #93
