### PR TITLE
Move and bump JSHint dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,9 +6,6 @@ module.exports = function(grunt) {
 		nodeunit: {
 			files: ['test/**/*.js']
 		},
-		lint: {
-			files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
-		},
 		watch: {
 			files: '<config:lint.files>',
 			tasks: 'default'
@@ -78,13 +75,11 @@ module.exports = function(grunt) {
 				eqnull: true,
 				smarttabs: true,
 				node: true,
-				es5: true,
-				strict: false
+				strict: false,
+				browser: true
+
 			},
-			globals: {
-				Image: true,
-				window: true
-			}
+			all: ['Gruntfile.js', 'tasks/**/*.js', 'test/**/*.js'],
 		}
 	});
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 	},
 	"dependencies": {
 		"grunt": "~0.4.0",
-		"grunt-contrib-jshint": "~0.2.0",
 		"uglify-js": "~2.2.5",
 		"phantomjs": "1.9.2-0",
 		"svgo":"~0.3.7",
@@ -40,6 +39,7 @@
 	},
 	"devDependencies": {
 		"grunt-cli":"~0.1",
+		"grunt-contrib-jshint": "~0.7.2",
 		"grunt-contrib-nodeunit": "0.2.2"
 	},
 	"keywords": [

--- a/test/gfile.js
+++ b/test/gfile.js
@@ -2,7 +2,6 @@ var path = require( 'path' );
 var GrunticonFile = require( path.join( '..', 'lib', 'grunticon-file') ).grunticonFile;
 var fs = require('fs');
 
-"use strict";
 var gf, constructor = GrunticonFile;
 
 exports['constructor'] = {


### PR DESCRIPTION
- Fixes target so it is also actually run.
- Fixed JSHint failure due to calling "use strict" in the wrong place. Since the file is run in node only, strict is already assumed.
