### PR TITLE
Make svgToPng and png conversion optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
 		"grunt-svgmin": "0.3.0",
 		"directory-encoder": "0.4.0",
 		"directory-colorfy": "0.1.0",
-		"rsvp": "1.2.0",
-		"svg-to-png": "0.2.0"
+		"rsvp": "3.0.3"
 	},
 	"devDependencies": {
 		"grunt-cli": "~0.1",


### PR DESCRIPTION
Resolves #109

Specify `null` for `datapngcss` or `urlpngcss` if those files aren't needed. `svg-to-png` is now optional. Throw an error if it isn't installed.

Just my take on this. Probably should indicate in the README that svg-to-png is no longer installed by default.
