### PR TITLE
update pngcrush-installer for v0.6.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "grunt-grunticon",
 	"description": "A mystical CSS icon solution",
-	"version": "0.6.14",
+	"version": "0.6.15",
 	"homepage": "https://github.com/filamentgroup/grunticon",
 	"author": {
 		"name": "Scott Jehl",
@@ -34,7 +34,7 @@
 		"uglify-js": "~2.2.5",
 		"phantomjs": "1.9.2-0",
 		"svgo":"~0.3.7",
-		"pngcrush-installer": "1.7.67-2",
+		"pngcrush-installer": "1.7.70-1",
 		"fs-extra": "0.6.3",
 		"xmldom": "0.1.16"
 	},


### PR DESCRIPTION
- updates grunticon version from 0.6.14 to 0.6.15
- fixes tarball download and build by updating pngcrush-installer https://github.com/jlembeck/pngcrush-installer/pull/12

I think you don't want to merge this into master since you have beta in master. But I don't know how to send the patch since there is no v0.6.14 branch.
