### PR TITLE
set default loadersnippet extension to js instead of txt

### DIFF
--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -37,7 +37,7 @@ module.exports = function( grunt , undefined ) {
 				banner: path.join( __dirname, 'grunticon', 'static', 'grunticon.loader.banner.js')
 			},
 			previewhtml: "preview.html",
-			loadersnippet: "grunticon.loader.txt",
+			loadersnippet: "grunticon.loader.js",
 			cssbasepath: path.sep,
 			customselectors: {},
 			cssprefix: ".icon-",


### PR DESCRIPTION
set the default extension to js so that it could be loaded in the browser through a script tag without additional configuration or supplying a custom filename in the task definition.
