### PR TITLE
allow specifying a custom PNG fallback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ Default value: `"png/"`
 
  The name of the generated folder containing the generated PNG images.
 
+#### options.pngpath
+Type: `String`
+Default value: value of `options.pngfolder`
+
+Allows you to specify a custom URL to serve fallback PNGs at.
+
+Example:
+
+```
+{
+    pngpath: "/assets/icons/png"
+}
+```
+
+Will generate PNG fallbacks like:
+
+```
+.icon-bar {
+	background-image: url('/assets/icons/png/bar.png');
+	background-repeat: no-repeat;
+}
+```
+
 #### options.cssprefix
 Type: `String`
 Default value: `".icon-"`

--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -45,6 +45,7 @@ module.exports = function( grunt , undefined ) {
 			defaultHeight: "300px",
 			colors: {},
 			pngfolder: "png",
+			pngpath: "",
 			template: "",
 			previewTemplate: path.join( __dirname, "..", "example", "preview.hbs" )
 		});
@@ -97,6 +98,7 @@ module.exports = function( grunt , undefined ) {
 
 		var o2 = {
 			pngfolder: pngfolder,
+			pngpath: config.pngpath,
 			customselectors: config.customselectors,
 			template: path.resolve( config.template ),
 			previewTemplate: path.resolve( config.previewTemplate ),


### PR DESCRIPTION
Fixes https://github.com/filamentgroup/grunticon/issues/58

Dependent on: https://github.com/filamentgroup/directory-encoder/pull/12
