### PR TITLE
Early return when Grunticon has no files to read

### DIFF
--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -63,6 +63,7 @@ module.exports = function( grunt , undefined ) {
 		if( files.length === 0 ){
 			grunt.log.writeln( "Grunticon has no files to read!" );
 			done();
+			return;
 		}
 
 		files = files.map( function( file ){


### PR DESCRIPTION
If no files are passed to Grunticon, it will fail with the error
"Grunticon has no files to read!", and call the async `done()` callback. 
However, it will continue to execute the task, which will fail when Grunticon
tries to access the first file.

This pull request adds an early return after the `done()` callback is called
when Grunticon has no files to read. This will prevent execution after the
warning message is displayed, which will make the error more obvious, avoid
crashing, and make debugging easier.
