### PR TITLE
pngpath should also affect pngpaths in the datapngcss

### DIFF
--- a/tasks/grunticon.js
+++ b/tasks/grunticon.js
@@ -97,6 +97,7 @@ module.exports = function( grunt , undefined ) {
 
 		var o = {
 			pngfolder: pngfolder,
+			pngpath: config.pngpath,
 			customselectors: config.customselectors,
 			template: path.resolve( config.template ),
 			previewTemplate: path.resolve( config.previewTemplate ),


### PR DESCRIPTION
When source folder contains both svg's and png's the pngpath option should also affect the url's generated for the css containing the svg data urls.
